### PR TITLE
Step 3 - Implement Pact Verifier

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,19 @@ jobs:
         PACT_BROKER_TOKEN: ${{ secrets.PACT_BROKER_TOKEN }}
         GIT_COMMIT: ${{ github.sha }}
       run: ./mvnw clean verify
-    
+
+    - name: Can I Deploy
+      env:
+        PACT_BROKER_URL: ${{ secrets.PACT_BROKER_URL }}
+        PACT_BROKER_TOKEN: ${{ secrets.PACT_BROKER_TOKEN }}
+      run: |
+        docker run --rm \
+          -e PACT_BROKER_URL=${{ secrets.PACT_BROKER_URL }} \
+          -e PACT_BROKER_TOKEN=${{ secrets.PACT_BROKER_TOKEN }} \
+          pactfoundation/pact-cli:latest broker can-i-deploy \
+          --pacticipant order-service \
+          --version ${{ github.sha }}
+
     - name: Test Report
       uses: dorny/test-reporter@v1
       if: success() || failure()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,10 @@ jobs:
         cache: maven
     
     - name: Build with Maven
+      env:
+        PACT_BROKER_URL: ${{ secrets.PACT_BROKER_URL }}
+        PACT_BROKER_TOKEN: ${{ secrets.PACT_BROKER_TOKEN }}
+        GIT_COMMIT: ${{ github.sha }}
       run: ./mvnw clean verify
     
     - name: Test Report

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,9 +37,9 @@ jobs:
         PACT_BROKER_TOKEN: ${{ secrets.PACT_BROKER_TOKEN }}
       run: |
         docker run --rm \
-          -e PACT_BROKER_URL=${{ secrets.PACT_BROKER_URL }} \
-          -e PACT_BROKER_TOKEN=${{ secrets.PACT_BROKER_TOKEN }} \
           pactfoundation/pact-cli:latest broker can-i-deploy \
+          --broker-base-url=${PACT_BROKER_URL} \
+          --broker-token=${PACT_BROKER_TOKEN} \
           --pacticipant order-service \
           --version ${{ github.sha }}
 

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,18 @@
 			<version>1.13.9</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>au.com.dius.pact.provider</groupId>
+			<artifactId>junit5spring</artifactId>
+			<version>4.6.2</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>au.com.dius.pact.provider</groupId>
+			<artifactId>spring</artifactId>
+			<version>4.6.2</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,16 @@ spring:
   application:
     name: order-service
 
+pactbroker:
+  url: ${PACT_BROKER_URL:https://pact-mock.pactflow.io}
+  auth:
+    token: ${PACT_BROKER_TOKEN:2NxGdiTyTj6MJ8N4AtEDhg}
+pact:
+  provider:
+    branch: ${GIT_BRANCH:main}
+    version: ${GIT_COMMIT}
+  verifier:
+    publishResults: ${CI:false}
 inventory:
   service:
     url: http://localhost:4000/v1

--- a/src/test/kotlin/com/pactmock/order_service_demo/PactProviderVerificationTest.kt
+++ b/src/test/kotlin/com/pactmock/order_service_demo/PactProviderVerificationTest.kt
@@ -1,0 +1,84 @@
+package com.pactmock.order_service_demo
+
+import TestConfig
+import au.com.dius.pact.provider.junit5.HttpTestTarget
+import au.com.dius.pact.provider.junit5.PactVerificationContext
+import au.com.dius.pact.provider.junitsupport.Provider
+import au.com.dius.pact.provider.junitsupport.State
+import au.com.dius.pact.provider.junitsupport.loader.PactBroker
+import au.com.dius.pact.provider.junitsupport.loader.PactBrokerAuth
+import au.com.dius.pact.provider.junitsupport.loader.PactFolder
+
+import au.com.dius.pact.provider.spring.junit5.PactVerificationSpringProvider
+import com.pactmock.order_service_demo.models.Item
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.web.client.RestTemplate
+import java.net.URI
+
+@ExtendWith(SpringExtension::class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Provider("order-service")
+@PactBroker(
+    url = "\${pactbroker.url}",
+    authentication = PactBrokerAuth(token = "\${pactbroker.auth.token}"),
+)
+@Import(TestConfig::class)
+class PactProviderVerificationTest {
+
+    @Autowired
+    private lateinit var restTemplate: RestTemplate
+
+    @LocalServerPort
+    private var port: Int = 0
+
+    @BeforeEach
+    fun setUp(context: PactVerificationContext) {
+        context.target = HttpTestTarget.fromUrl(URI.create("http://localhost:$port").toURL())
+        System.setProperty("pact.verifier.publishResults", System.getenv("CI") ?: "false")
+        System.setProperty("pact.provider.version", System.getenv("GIT_COMMIT") ?: "unknown")
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationSpringProvider::class)
+    fun pactVerificationTestTemplate(context: PactVerificationContext) {
+        context.verifyInteraction()
+    }
+
+    @State("There are 2 items")
+    fun `There are 2 items`() {
+        val mockItems = listOf(
+            Item(1L, "Test Item 1", "This is a test item", 5),
+            Item(2L, "Test Item 2", "This is another test item", 3)
+        )
+        restTemplate.givenItemsAreAvailable(mockItems)
+    }
+
+    @State("There is an item with stock")
+    fun `There is an item with stock`() {
+        val mockItem = Item(1L, "Test Item 1", "This is a test item", 5)
+        restTemplate.givenItemsAreAvailable(listOf(mockItem))
+        restTemplate.givenItemBookingSucceeds(1L, 3)
+    }
+
+    @State("There is an error")
+    fun `There is an error`() {
+        with(restTemplate){
+            givenItemBookingFails(1L, 1)
+            givenItemReleaseSucceeds(1L, 1)
+        }
+
+    }
+
+    @State("There is an item with 0 stock")
+    fun `There is an item with 0 stock`() {
+        val mockItem = Item(1L, "Out of Stock Item", "This item is out of stock", 0)
+        restTemplate.givenItemsAreAvailable(listOf(mockItem))
+    }
+}

--- a/src/test/kotlin/com/pactmock/order_service_demo/TestConfig.kt
+++ b/src/test/kotlin/com/pactmock/order_service_demo/TestConfig.kt
@@ -1,0 +1,15 @@
+import io.mockk.mockk
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Primary
+import org.springframework.web.client.RestTemplate
+
+@TestConfiguration
+class TestConfig {
+
+    @Bean
+    @Primary
+    fun mockedRestTemplate(): RestTemplate {
+        return mockk<RestTemplate>()
+    }
+}


### PR DESCRIPTION
### Pull Request Description

#### Summary

This pull request implements Pact contract verification for the order service project.

#### Changes
1. **GitHub Actions Workflow**
   - Updated `.github/workflows/build.yml` to include environment variables for Pact broker URL and token, along with the Git commit hash.

2. **Maven Dependencies**
   - Added `junit5spring` and `spring` dependencies from `au.com.dius.pact.provider` to the `pom.xml` to support Pact verification with JUnit5 and Spring.

3. **Application Configuration**
   - Modified `application.yml` to include configurations for the Pact broker URL, authentication token, and settings for Pact provider verification.

4. **Pact Provider Verification Test**
   - Created `PactProviderVerificationTest.kt` to define Pact verification tests with various states to simulate different conditions of the order service.

5. **Test Configuration**
   - Added `TestConfig.kt` to provide a mocked REST template needed for the Pact provider verification tests.

#### Purpose
The changes introduce automated contract testing to ensure the order-service interacts correctly with its consumers, enhancing the reliability and integration of the microservices involved.

#### Note
This implementation sets up the project to publish Pact verification results if the CI environment variable is set to true.

---

This PR addresses step 3 in our integration plan for consumer-driven contract testing. Please review and ensure the configurations are correct for our CI/CD pipelines.